### PR TITLE
Add possibility to adjust metadata file ending

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Updating: when using npx, make sure that it takes the new version. You can alway
 
 #### Configuration options
 
-You should use the config file at least for layers configuration. But there are also other configuration options. Whole config example: 
+You should use the config file at least for layers configuration. But there are also other configuration options. Whole config example:
 
 ```json
 {
@@ -53,11 +53,31 @@ You should use the config file at least for layers configuration. But there are 
   "layerConfigurations": [
     {
       "growEditionSizeTo": 100,
-      "layersOrder": [{ "name": "face" }, { "name": "head" }, { "name": "eyes" }]
+      "layersOrder": [
+        {
+          "name": "face"
+        },
+        {
+          "name": "head"
+        },
+        {
+          "name": "eyes"
+        }
+      ]
     },
     {
       "growEditionSizeTo": 110,
-      "layersOrder": [{ "name": "pinkyFace" }, { "name": "head" }, { "name": "eyes" }]
+      "layersOrder": [
+        {
+          "name": "pinkyFace"
+        },
+        {
+          "name": "head"
+        },
+        {
+          "name": "eyes"
+        }
+      ]
     }
   ],
   "shuffleLayerConfigurations": false,
@@ -86,6 +106,7 @@ You should use the config file at least for layers configuration. But there are 
   "outputJsonFileName": "metadata.json",
   "outputImagesCarFileName": "images.car",
   "outputMetadataCarFileName": "metadata.car",
+  "outputMetadataFileEnding": ".json",
   "editionNameFormat": "#",
   "tags": "tag1,tag2,tag3",
   "preview": {

--- a/example/.nftartmakerrc
+++ b/example/.nftartmakerrc
@@ -5,6 +5,7 @@
     "width": 300,
     "height": 300
   },
+  "outputMetadataFileEnding": "",
   "layerConfigurations": [
     {
       "growEditionSizeTo": 192,

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,10 @@ const outputImagesCarFileName =
   customConfig?.config?.outputCarFileName || 'images.car';
 const outputMetadataCarFileName =
   customConfig?.config?.outputCarFileName || 'metadata.car';
+const outputMetadataFileEnding =
+  typeof customConfig?.config?.outputMetadataFileEnding === 'string'
+    ? customConfig?.config?.outputMetadataFileEnding
+    : '.json';
 
 const editionNameFormat = customConfig?.config?.editionNameFormat || '#';
 
@@ -99,6 +103,7 @@ const config = {
   metadataSchemaMapper,
   defaultMetadataSchemaMapper,
   nftStorageApiToken,
+  outputMetadataFileEnding,
 };
 
 export default config;

--- a/src/nft-maker.ts
+++ b/src/nft-maker.ts
@@ -41,6 +41,7 @@ const {
   outputImagesDirName,
   editionNameFormat,
   shuffleLayerConfigurations,
+  outputMetadataFileEnding,
 } = config;
 
 const basePath = cwd();
@@ -209,7 +210,7 @@ const prepareMetadataAndAssets = (_edition: number) => {
 
   if (!svgBase64DataOnly) {
     fs.writeFileSync(
-      `${buildDir}/${outputJsonDirName}/${_edition}.json`,
+      `${buildDir}/${outputJsonDirName}/${_edition}${outputMetadataFileEnding}`,
       JSON.stringify(tempMetadata, null, 2)
     );
 

--- a/tests/.nftartmakerrc
+++ b/tests/.nftartmakerrc
@@ -7,6 +7,7 @@
   },
   "layersDirName": "../example/layers",
   "outputDirName": "../example/output",
+  "outputMetadataFileEnding": "",
   "layerConfigurations": [
     {
       "growEditionSizeTo": 192,


### PR DESCRIPTION
Some base functionalities of ERC721 or ERC721A does not expect ".json" file ending. 

With this configuration it is possible to overwrite "1.json" => "1"
 ```json
{
  "outputMetadataFileEnding": "",
}
```
The default if the option is not set remains ".json"