### PR TITLE
Add "updateImageCID" command to update image CID metadata

### DIFF
--- a/.nftartmakerrc
+++ b/.nftartmakerrc
@@ -5,8 +5,8 @@
     "width": 300,
     "height": 300
   },
-  "layersDirName": "../example/layers",
-  "outputDirName": "../example/output",
+  "layersDirName": "./example/layers",
+  "outputDirName": "./example/output",
   "outputMetadataFileExtension": "",
   "layerConfigurations": [
     {
@@ -38,5 +38,6 @@
       ]
     }
   ],
-  "nftStorageApiToken": ""
+  "nftStorageApiToken": "",
+  "overwriteImageCID": "abcd"
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Updating: when using npx, make sure that it takes the new version. You can alway
 - you can also pack files using `npx nft-art-maker pack` (always recommended!) - this will pack all files using ipfs-car into one images.car and metadata.car files, which you can upload using services like nft.storage
 - check how many unique assets is generated. `npx nft-art-maker check` Sometimes the names of files can be misleading when there are not enough layers to achieve the required amount of assets. This probably needs some rewrites in the future.
 - upload packed car files to nft.storage. `npx nft-art-maker upload` - this will upload all packed ipfs-car files to nft.storage. Set "nftStorageApiToken" config option to your API token
+- overwrite image CID. `npx nft-art-maker updateImageCID` - this will update all metadata files based on the config option `overwriteImageCID`
 
 #### Configuration options
 
@@ -115,7 +116,8 @@ You should use the config file at least for layers configuration. But there are 
     "imageRatio": 1,
     "imageName": "preview.png"
   },
-  "nftStorageApiToken": "Your nft.storage API token"
+  "nftStorageApiToken": "Your nft.storage API token",
+  "overwriteImageCID": "Your image CID after upload to your IPFS storage."
 }
 ```
 
@@ -293,6 +295,17 @@ layers/
 ### Upload packed car files to nft.storage
 
 This package has a small helper to upload the packed car files to nft.storage. To archive the only requirement is addition in the .nftartmakerrc config file: `"nftStorageApiToken": "Your nft.storage API token"`. See the example above.
+
+
+### Upload image folder with NFT UP or Pinata (or any other 3rd party IPFS storage provider.)
+
+In case you are dealing with a very large collection and the ipfs upload failed for some reasons you can first upload the images to an IPFS provider.
+
+After you received the CID of the image location following steps are required: 
+
+1. update your config file `overwriteImageCID` option with your CID.
+2. run `nft-art-maker updateImageCID` which will re-generate your metadata files with the image CID.
+3. upload your metadata json folder to your preferred location. 
 
 ### Try the example
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,8 @@ const outputMetadataFileExtension =
     ? customConfig?.config?.outputMetadataFileExtension
     : '.json';
 
+const overwriteImageCID = customConfig?.config?.overwriteImageCID;
+
 const editionNameFormat = customConfig?.config?.editionNameFormat || '#';
 
 const shuffleLayerConfigurations =
@@ -104,6 +106,7 @@ const config = {
   defaultMetadataSchemaMapper,
   nftStorageApiToken,
   outputMetadataFileExtension,
+  overwriteImageCID,
 };
 
 export default config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { argv, exit } from 'process';
 import { buildSetup, checkUniqGeneratedDna, startCreating } from './nft-maker';
 import { executePreviewGeneration } from './create-preview';
-import { ipfsPack } from './ipfs-pack';
+import { ipfsPack, updateMetadataImageCID } from './ipfs-pack';
 import packageJson from '../package.json';
 import { uploadCar } from './upload-car';
 
@@ -13,6 +13,7 @@ const COMMANDS = {
   pack: 'pack',
   check: 'check',
   upload: 'upload',
+  updateImageCID: 'updateImageCID',
 };
 
 const args = argv;
@@ -55,4 +56,8 @@ if (command === COMMANDS.check) {
 
 if (command === COMMANDS.upload) {
   uploadCar();
+}
+
+if (command === COMMANDS.updateImageCID) {
+  updateMetadataImageCID();
 }

--- a/src/ipfs-pack.ts
+++ b/src/ipfs-pack.ts
@@ -1,12 +1,12 @@
 import {
+  accessSync,
+  constants,
   createReadStream,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   writeFileSync,
-  accessSync,
-  constants,
-  readdirSync,
 } from 'fs';
 import { packToFs } from 'ipfs-car/pack/fs';
 import { FsBlockStore } from 'ipfs-car/blockstore/fs';
@@ -96,33 +96,27 @@ const updateSummaryMetadataFile = (imagesBaseCid: string | undefined) => {
   if (newEditions && newEditions.length && imagesBaseCid) {
     // The metadata structure can be any type because it is configurable
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const modifiedEditions = newEditions.map((item: any) => {
+    const modifiedEditions = newEditions.map((item: any, iteration) => {
+      const edition = config.metadataSchemaMapper.edition
+        ? dotProp.get<number>(item, config.metadataSchemaMapper.edition)
+        : iteration + 1;
       dotProp.set(
         item,
         config.metadataSchemaMapper['image.href'],
-        `https://ipfs.io/ipfs/${imagesBaseCid}/${dotProp.get<number>(
-          item,
-          config.metadataSchemaMapper.edition
-        )}.png`
+        `https://ipfs.io/ipfs/${imagesBaseCid}/${edition}.png`
       );
       dotProp.set(
         item,
         config.metadataSchemaMapper['image.ipfsUri'],
-        `ipfs://${imagesBaseCid}/${dotProp.get<number>(
-          item,
-          config.metadataSchemaMapper.edition
-        )}.png`
+        `ipfs://${imagesBaseCid}/${edition}.png`
       );
       dotProp.set(
         item,
         config.metadataSchemaMapper['image.ipfsCid'],
         imagesBaseCid
       );
-      dotProp.set(
-        item,
-        config.metadataSchemaMapper['image.fileName'],
-        `${dotProp.get<number>(item, config.metadataSchemaMapper.edition)}.png`
-      );
+      const imageFilename = config.metadataSchemaMapper['image.fileName'];
+      dotProp.set(item, imageFilename, `${edition}.png`);
       return item;
     });
 

--- a/src/ipfs-pack.ts
+++ b/src/ipfs-pack.ts
@@ -135,21 +135,16 @@ const updateMetadataFiles = (imagesBaseCid: string | undefined) => {
   for (const metadataFile of metadataAssetsList) {
     const rawdata = readFileSync(`${jsonOutputDir}/${metadataFile}`);
     const fileJSON = JSON.parse(rawdata.toString());
+    const edition = metadataFile;
     dotProp.set(
       fileJSON,
       config.metadataSchemaMapper['image.href'],
-      `https://ipfs.io/ipfs/${imagesBaseCid}/${dotProp.get<number>(
-        fileJSON,
-        config.metadataSchemaMapper.edition
-      )}.png`
+      `https://ipfs.io/ipfs/${imagesBaseCid}/${edition}.png`
     );
     dotProp.set(
       fileJSON,
       config.metadataSchemaMapper['image.ipfsUri'],
-      `ipfs://${imagesBaseCid}/${dotProp.get<number>(
-        fileJSON,
-        config.metadataSchemaMapper.edition
-      )}.png`
+      `ipfs://${imagesBaseCid}/${edition}.png`
     );
     dotProp.set(
       fileJSON,
@@ -159,10 +154,7 @@ const updateMetadataFiles = (imagesBaseCid: string | undefined) => {
     dotProp.set(
       fileJSON,
       config.metadataSchemaMapper['image.fileName'],
-      `${dotProp.get<number>(
-        fileJSON,
-        config.metadataSchemaMapper.edition
-      )}.png`
+      `${edition}.png`
     );
     writeFileSync(
       `${jsonOutputDir}/${metadataFile}`,
@@ -212,4 +204,19 @@ export const ipfsPack = async () => {
   } catch (e) {
     console.log(`Ipfs pack: ${(e as unknown as Error).message}`);
   }
+};
+
+export const updateMetadataImageCID = async () => {
+  const imageCid = config.overwriteImageCID;
+
+  if (!imageCid) {
+    console.log(
+      'There is no "updateImageCid" config option set. Task will exit without rewriting files.'
+    );
+    return;
+  }
+  updateMetadataFiles(imageCid);
+  updateSummaryMetadataFile(imageCid);
+
+  console.log('Done! Check the output directory.');
 };

--- a/src/ipfs-pack.ts
+++ b/src/ipfs-pack.ts
@@ -211,7 +211,7 @@ export const updateMetadataImageCID = async () => {
 
   if (!imageCid) {
     console.log(
-      'There is no "updateImageCid" config option set. Task will exit without rewriting files.'
+      'There is no "overwriteImageCID" config option set. Task will exit without rewriting files.'
     );
     return;
   }

--- a/tests/.nftartmakerrc
+++ b/tests/.nftartmakerrc
@@ -7,6 +7,7 @@
   },
   "layersDirName": "../example/layers",
   "outputDirName": "../example/output",
+  "outputMetadataFileExtension": "",
   "layerConfigurations": [
     {
       "growEditionSizeTo": 192,

--- a/tests/nft-maker.test.ts
+++ b/tests/nft-maker.test.ts
@@ -4,7 +4,7 @@ import {
   startCreating,
 } from '../src/nft-maker';
 import config from '../src/config';
-import { ipfsPack } from '../src/ipfs-pack';
+import { ipfsPack, updateMetadataImageCID } from '../src/ipfs-pack';
 import { cwd } from 'process';
 import { existsSync } from 'fs';
 import { uploadCar } from '../src/upload-car';
@@ -32,5 +32,9 @@ describe('nft-maker tests', () => {
     const { cidMeta, cidImages } = await uploadCar();
     expect(typeof cidMeta).toBe('string');
     expect(typeof cidImages).toBe('string');
+  });
+
+  it('generate examples and rename CID based on "updateImageCid"', async () => {
+    await updateMetadataImageCID();
   });
 });


### PR DESCRIPTION
Currently edition field in metadata is required. 

This PR adds the option to not use the edition field for the pack command, and falls back to the iteration of the loop.

This would close #22 and improve #24 